### PR TITLE
Add blog post: "How to Organize UI Text in Code"

### DIFF
--- a/articles/how-to-organize-ui-text-in-code-best-practices-for-scalable-localized-apps.md
+++ b/articles/how-to-organize-ui-text-in-code-best-practices-for-scalable-localized-apps.md
@@ -1,0 +1,260 @@
+&nbsp;
+![Blog cover photo](https://storage.googleapis.com/bitloops-github-assets/Blog%20Images/How%20to%20Organize%20UI%20Text%20in%20Code%3A%20Best%20Practices%20for%20Scalable%2C%20Localized%20Apps/final%20cover%20image.jpeg)
+&nbsp;
+---
+title: "How to Organize UI Text in Code: Best Practices for Scalable, Localized Apps"
+subtitle: "Understanding Chrome Text, UI Text, and Content Text and why their ownership defines your product’s scalability."
+author: "Georgios Giamvrias"
+date: 2025-11-06
+tags: ["frontend architecture", "UI-text", "Chrome-Text", "CMS", “Content-Text”, “Content-Management”, "Bitloops"]
+canonical_url: "https://medium.com/@georgiosgiamvrias/how-to-organize-ui-text-in-code"
+description: "Learn how to structure and manage text in your frontend codebase to improve scalability, localization, and developer collaboration."
+image: "cover-image-url.jpg"
+reading_time: 6
+---
+
+# How to Organize UI Text in Code: Best Practices for Scalable, Localized Apps
+
+## The Mystery of the Missing Words
+
+Every frontend developer has faced this moment:  
+You open a codebase and wade through a jungle of words - some hard-coded, some localized, some mysteriously pulled from a content management system (CMS) no one dares to touch.  
+Some text lives inside components. Some hide in JSON files. Others lost in translation - literally.
+
+And then it happens - marketing wants to “just change a few words.”  
+You sigh, open VS Code, and realize that the labels in production are a chaotic mix of “content,” “UI strings” and something undefined in between.
+
+Beneath all this confusion lies an invisible layer of frontend architecture - the way we structure, name, and own our text.
+
+—
+—
+##The Invisible Layer of Frontend Architecture 
+
+Every word in a product needs clear ownership — whether it sits with product, engineering, or marketing.
+ Without it, copy becomes inconsistent, code grows tangled, and scaling - or even maintaining - the product gets slower and riskier over time.
+What makes this especially tricky is that text doesn’t live in just one place. Some strings sit inside components, others in translation files, and others are editable through a CMS. Each layer has different owners, workflows, and risks.
+When these boundaries blur, everything else follows. Engineering debt grows because the same label appears in five different places with slightly different names. Localization gets messy, with translators unsure what belongs in technical files and what’s marketing copy. Design alignment breaks as text length and tone shift without context. And marketing loses confidence because they can’t safely edit what they need - or worse, they edit what they shouldn’t.
+The result is a quiet kind of chaos: a codebase where no one knows who owns what. It’s not just a communication issue — it’s an architectural one. Without defined ownership, language becomes one of the most fragile layers of your frontend. Strings start duplicating across files, version control becomes unreliable, and every minor text change risks a regression.
+Even localization and translation systems start to suffer. Translators rely on stable references, while editors need flexibility to adjust messaging. When those systems overlap, both break - translators touch content they shouldn’t, and editors face cryptic identifiers they can’t interpret.
+This is the invisible layer of frontend architecture: the way your product structures, stores, and governs its language. It’s subtle. It’s powerful. And when it’s neglected, scalability doesn’t collapse overnight - it frays quietly, through mismatched strings, layout bugs, and endless “who owns this text?” moments.
+—
+## Not All Text Is Created Equal
+
+### What is Chrome Text, UI Text, Content Text and User Text?
+
+Before diving deeper, it’s worth recognizing that every piece of text in a product plays a different role.  
+Broadly speaking, there are four main categories:
+
+- **Chrome Text:** the structural labels of your interface: buttons, menus, navigation items.  
+- **UI Text:** messages that communicate with users during interaction: empty states, confirmations, tooltips.  
+- **Content Text:** marketing or editorial copy that lives outside the product’s interface logic, like homepage headlines, blog titles, or product descriptions.  
+- **User Content:** everything created by users themselves: comments, usernames, reviews, uploaded content.
+
+The last two; Content Text and User Content are usually straightforward.  
+They already have clear ownership and storage patterns: marketing manages content through a CMS, and users generate their own data stored in a database.  
+Because they follow well-understood workflows, we won’t focus on them further here.
+
+The real architectural complexity lies in the first two: Chrome Text and UI Text -  
+the subtle, intertwined layers of language that live inside the product itself.  
+These are the strings that quietly shape usability, ownership, and scalability and they’re often the ones teams misunderstand the most.
+
+---
+
+## Wait… What is “Chrome Text” really?
+
+Before you ask - no, this has nothing to do with Google Chrome.  
+Ironically, the browser actually took its name from the same design concept.
+
+In design systems and component libraries, “chrome” refers to the structural scaffolding of your interface - the buttons, labels, menus, navigation, tooltips, and status messages that make your product feel interactive and alive.
+
+**Chrome Text** is the language that lives inside that scaffolding.  
+It’s the backbone of your interface - short, functional, and brutally consistent.  
+It doesn’t sell. It doesn’t inspire. It tells.  
+It says: “Save.” “Cancel.” “Settings.” “Sign out.”  
+You never notice it when it’s right - only when it’s missing.
+
+Chrome Text is the part of the UI that developers usually control, because it’s tied directly to logic, states, and user flows.  
+It lives close to the code; in i18n files, translation keys, or component definitions.  
+It evolves with features, not marketing campaigns.
+
+Think of it as the grammar of your interface: precise, repeatable, invisible… until it breaks.
+
+---
+
+## And What About “UI Text”?
+
+If Chrome Text is the skeleton, UI Text is the voice that brings it to life.  
+It’s the part that reassures, guides, and gently teaches the user how to interact with that skeleton.
+
+Where Chrome Text says *what* something is, UI Text says *why* and *what happens next*.
+
+| Chrome | UI Text |
+|--------|----------|
+| “Upload” | “Upload a file to continue.” |
+| “Delete” | “Are you sure you want to delete this item?” |
+
+UI Text sits in the space between product and people.  
+It blends microcopy, UX writing, and intent.  
+It’s empathetic enough to speak human, but structured enough to live in your codebase.  
+It’s where Product and UX teams meet developers halfway balancing clarity, tone, and functionality.
+
+When done right, UI Text is invisible orchestration:  
+the reason a user feels guided, not confused; confident, not lost.  
+When done wrong, it’s the quiet cause of support tickets, failed conversions, and “I didn’t know I could do that.”
+
+So, while Chrome Text forms the mechanical skeleton of your product,  
+UI Text is the conversation layer that makes that skeleton feel alive.  
+Together, they define not just how your product works - but how it speaks.
+
+---
+
+## Summary: The Four Text Layers of a Frontend App
+
+| Type | Example | Owner | Where It Lives |
+|------|----------|--------|----------------|
+| **Chrome Text** | “Save”, “Cancel”, “Settings”, “Sign Out” | Developer | In code / i18n files |
+| **UI Text** | “No results found”, “Upload a file to continue” | Product / UX | In code or translation files |
+| **Content Text** | Blog titles, landing page copy, product descriptions | Marketing | In CMS or API |
+| **User Content** | Comments, names, reviews | Users | In database |
+
+—
+
+&nbsp;
+![Chrome Text and UI Text Illustration](https://storage.googleapis.com/bitloops-github-assets/Blog%20Images/How%20to%20Organize%20UI%20Text%20in%20Code%3A%20Best%20Practices%20for%20Scalable%2C%20Localized%20Apps/FINAL%20DEV%20VS%20PM.jpeg)
+&nbsp;
+
+—
+
+
+
+## The Invisible Layer of Frontend Architecture 3rd version 
+
+Every word in a product needs clear ownership — whether it sits with product, engineering, or marketing.  
+Without it, copy becomes inconsistent, code grows tangled, and scaling — or even maintaining - the product gets slower and riskier over time.  
+
+What makes this especially tricky is that text doesn’t live in just one place. Some strings sit inside components, others in translation files, and others are editable through a CMS. Each layer has different owners, workflows, and risks. When these boundaries blur, everything else follows: engineering debt grows because the same label appears in five places with slightly different names; localization gets messy, with translators unsure what belongs in i18n files and what’s marketing copy; design alignment breaks as text length and tone shift without context; and marketing loses confidence because they can’t safely edit what they need — or worse, they edit what they shouldn’t.  
+
+The truth is, text ownership isn’t just about keeping things tidy - it’s a matter of architecture. **Chrome Text** belongs close to the code, because it’s tied to interface logic and behavior. Version-controlling it ensures consistency, predictability, and stable releases. **Content Text**, on the other hand, belongs in the CMS, where it can evolve quickly without requiring a redeploy every time marketing updates a headline. When these two worlds collide, you end up with what developers often call *semantic spaghetti* — strings with no clear home, no ownership, and no predictable workflow.  
+
+This confusion also spills into localization. Translators depend on stable keys for UI text, like:  
+
+```tsx
+<Button>{t("save")}</Button>
+```
+while content editors need flexibility for marketing copy, such as:
+```tsx
+<h1>{cms.heroTitle}</h1>
+```
+When the boundaries blur, both systems break - translators see marketing copy they shouldn’t touch, and marketers stare at translation keys they can’t interpret.
+This is the invisible layer of frontend architecture: the way your product structures, stores, and governs its language. It’s subtle. It’s powerful. And when it’s neglected, scalability doesn’t collapse overnight - it frays quietly, through mismatched strings, layout bugs, and endless “who owns this text?” moments.
+
+—
+
+
+## When Text Lives in the Wrong Place
+
+Imagine your “Sign Up” button text lives in the CMS because “marketing might want to change it.”  
+Now every render of that button depends on an external API call - to fetch a piece of text that almost never changes.
+
+That means one more network request. One more point of failure.  
+If the CMS is slow, your button is slow.  
+If the CMS goes down, your button disappears.  
+And all because someone wanted to tweak the wording without asking a developer.
+
+Meanwhile, your content team wonders why they can’t change the homepage hero title because that one is hard-coded in the frontend.
+
+Then one day, someone in marketing decides to “optimize conversions” and edits the label to: “Create Account Now!”  
+The new text is longer - so your layout shifts, the button overflows on mobile and your neatly aligned login form looks like it’s been through a car crash.
+
+The result?  
+A build where no one knows who owns which words - and every small text change becomes a deployment nightmare.
+
+When content lives in the wrong layer, the whole system becomes fragile.  
+CMS text isn’t built for real-time UI rendering; it’s built for flexible marketing copy where length, spacing and structure are accounted for.  
+Frontend text, on the other hand, is tightly coupled to layout and logic - change it without context and the entire design equilibrium breaks.
+
+**This is why ownership boundaries matter:**  
+Your CMS should feed messages, not mechanics.  
+Your code should handle interface language, not marketing slogans.
+
+—
+&nbsp;
+![Two button meme illustrating text ownership confusion](https://storage.googleapis.com/bitloops-github-assets/Blog%20Images/How%20to%20Organize%20UI%20Text%20in%20Code%3A%20Best%20Practices%20for%20Scalable%2C%20Localized%20Apps/two%20button%20meme.png)
+&nbsp;
+
+—
+
+## Why It’s Underrated
+
+Most developers never talk about text architecture.  
+It’s invisible. Boring. Not glamorous enough to make into a postmortem or sprint review.
+
+But quietly - beneath every polished UI - it decides whether your product feels coherent or chaotic.
+
+Poorly separated text layers are the silent cause of some of the most persistent product pain:  
+broken translations, layout regressions, missing strings, and those infamous “marketing-dev misfires” where no one knows who changed what, or why.
+
+It’s the kind of issue that doesn’t show up in performance dashboards - it shows up in meetings:  
+when someone says “Wait, who owns that label?”  
+or when an emergency hotfix happens because a CMS edit broke your checkout flow.
+
+And the irony?  
+We spend weeks perfecting component architecture, obsessing over pixel alignment and state management - yet we let language, the layer users actually read, exist in chaos.
+
+Good text architecture isn’t decoration.  
+It’s infrastructure.  
+It’s versioned, predictable, and owned - just like code.
+
+Because every word in a product is also a piece of logic:  
+it appears, disappears, drives user flow, and carries meaning.  
+Ignore it, and your product doesn’t just lose consistency - it loses credibility.
+
+---
+
+
+## How to Structure Text for Scalable Frontends
+
+1. **Keep Chrome Text Close to Code**  
+   Store short labels, button texts, and menu items in i18n or locale files.  
+   They’re part of your interface behavior, not your marketing message.
+
+2. **Let Content Text Live in the CMS**  
+   Marketing headlines, descriptions, FAQs, and long-form text belong in your CMS or API.  
+   They should be editable by non-developers and not require a redeploy.
+
+3. **Define Ownership Early**  
+   Add a one-liner in your team’s docs:  
+   > “If it’s part of the interface chrome, it lives in code.  
+   > If it’s part of the message, it lives in the CMS.”
+
+4. **Validate During Design Handoff**  
+   When importing designs (e.g., from Figma), mark which text elements are chrome vs. content.  
+   This makes design-to-code automation smarter and reduces rework later.
+
+---
+
+## The Takeaway
+
+Frontend architecture isn’t just about components, states, and APIs - it’s also about language ownership.  
+Separating Chrome Text from UI Text and Content Text, you give every team clear boundaries:
+
+- Developers control interface consistency  
+- Product and UX shape the user journey  
+- Marketing crafts the message  
+
+It’s not just good frontend architecture. It’s good collaboration.
+
+So next time someone says “just change the text,”  
+ask first: “Is it chrome, UI, or content?”
+
+That single question can save your entire team hours of confusion - and your codebase months of cleanup.
+
+---
+
+## Final Thought
+
+Words build trust.  
+But where those words live builds scalability.  
+Recognizing the invisible layer of frontend architecture - the realm of Chrome and UI Text - is what turns messy products into elegant systems.  
+And once you see it, you’ll never unsee it.
+

--- a/articles/how-to-organize-ui-text-in-code-best-practices-for-scalable-localized-apps.md
+++ b/articles/how-to-organize-ui-text-in-code-best-practices-for-scalable-localized-apps.md
@@ -1,17 +1,12 @@
-&nbsp;
-![Blog cover photo](https://storage.googleapis.com/bitloops-github-assets/Blog%20Images/How%20to%20Organize%20UI%20Text%20in%20Code%3A%20Best%20Practices%20for%20Scalable%2C%20Localized%20Apps/final%20cover%20image.jpeg)
-&nbsp;
 ---
-title: "How to Organize UI Text in Code: Best Practices for Scalable, Localized Apps"
-subtitle: "Understanding Chrome Text, UI Text, and Content Text and why their ownership defines your product’s scalability."
-author: "Georgios Giamvrias"
-date: 2025-11-06
-tags: ["frontend architecture", "UI-text", "Chrome-Text", "CMS", “Content-Text”, “Content-Management”, "Bitloops"]
-canonical_url: "https://medium.com/@georgiosgiamvrias/how-to-organize-ui-text-in-code"
-description: "Learn how to structure and manage text in your frontend codebase to improve scalability, localization, and developer collaboration."
-image: "cover-image-url.jpg"
-reading_time: 6
+title: How to Organize UI Text in Code: Best Practices for Scalable, Localized Apps
+description: A practical guide on structuring and managing text in your frontend codebase. Learn how to separate Chrome Text, UI Text, and Content Text to improve scalability, localization, and team collaboration.
+author: George
+date: 11-11-2025
+image: https://storage.googleapis.com/bitloops-github-assets/Blog%20Images/How%20to%20Organize%20UI%20Text%20in%20Code%3A%20Best%20Practices%20for%20Scalable%2C%20Localized%20Apps/final%20cover%20image.jpeg
+tags: ['Frontend Architecture', 'UI-text','Chrome-Text','CMS', 'Content-Text', 'Content-Management']
 ---
+
 
 # How to Organize UI Text in Code: Best Practices for Scalable, Localized Apps
 

--- a/index.json
+++ b/index.json
@@ -1,5 +1,8 @@
 [
   {
+    "id": "how-to-organize-ui-text-in-code-best-practices-for-scalable-localized-apps"
+  }, 
+  {
     "id": "we-raised-1M-to-fix-frontend-code-generation-propertly"
   },  
   {


### PR DESCRIPTION
Adds a new blog post about structuring frontend text layers:
- Chrome Text vs UI Text vs Content Text
- Ownership boundaries (code vs CMS)
- Localization and scalability implications

Includes:
- Cover and in-article images (GCS URLs)
- SEO frontmatter (title, description, tags, canonical)

